### PR TITLE
Add socket

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,6 +9,12 @@ import { Link } from "react-router-dom";
 import Radium from "radium";
 import MenuWrap from "./Components/MenuWrap/MenuWrap";
 import BurgerMenu from "react-burger-menu";
+import io from "socket.io-client";
+let socket = io();
+
+socket.on("connect", socket => {
+  console.log("Connected!");
+});
 
 const Menu = BurgerMenu["slide"];
 const RadiumLink = Radium(Link);

--- a/client/src/Components/GuestList/GuestList.js
+++ b/client/src/Components/GuestList/GuestList.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Menu, MenuDivider, MenuItem, Classes } from "@blueprintjs/core";
+import { Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
 
 class GuestList extends React.Component {
   _renderGuests() {

--- a/client/src/SocketHandler.js
+++ b/client/src/SocketHandler.js
@@ -1,0 +1,11 @@
+import io from "socket.io-client";
+
+let socket = io();
+
+let socketEvents = () => {
+  socket.on("connect", socket => {
+    console.log("Connected!");
+  });
+};
+
+export default socketEvents;

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -8,6 +8,9 @@ import ReactDOM from "react-dom";
 import App from "./App";
 import "./index.css";
 import reducer from "./rootReducer";
+import socketEvents from "./SocketHandler";
+
+socketEvents();
 
 const history = createHistory();
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,18 @@
 {
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "socket.io": "^1.7.3",
+    "socket.io-client": "^1.7.3"
   },
   "devDependencies": {
     "lint-staged": "^3.4.0",
     "pre-commit": "^1.2.2"
   },
   "lint-staged": {
-    "*.js": ["prettier --write", "git add"]
+    "*.js": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "pre-commit": "lint-staged",
   "scripts": {

--- a/server/index.js
+++ b/server/index.js
@@ -1,23 +1,29 @@
 // dependencies
-const express = require('express');
-const http = require('http');
-const bodyParser = require('body-parser');
-const path = require('path');
-
-// setting up server
+const express = require("express");
+const http = require("http");
+const bodyParser = require("body-parser");
+const path = require("path");
 const app = express();
 
-// middleware 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: false}));
-app.use(express.static(path.join(__dirname, './../client/build')));
+// setting up server
+let server = http.createServer(app);
 
-// test api
-app.get('/', (req, res)=> {
-    res.send('Hello World');
+let io = require("socket.io")(server);
+io.on("connection", socket => {
+  socket.emit("news", { hello: "world" });
+  console.log("Connected!");
 });
 
-// listening on port 3000
-app.listen(3000, err=> {
-    console.log('listening on port 3000');
+// middleware
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(express.static(path.join(__dirname, "./../client/build")));
+
+// test api
+app.get("/", (req, res) => {
+  res.send("Hello World");
+});
+
+server.listen(3000, err => {
+  console.log("listening on port 3000");
 });


### PR DESCRIPTION
Socket only works when client is served from the express server, which means running nodemon and running `npm run build` every time there's a change in the front end. Webpack dev server will not work because it is hosted on a different port than the Express app. Hopefully tuning the port number can fix this issue, otherwise I'll create another webpack to develop in socket mode.